### PR TITLE
fix msg opaque error in dr_msg_cb

### DIFF
--- a/libsrvkit/src/kafka.cc
+++ b/libsrvkit/src/kafka.cc
@@ -459,7 +459,7 @@ static int fn_upload_progress(void* data)
 
 static void dr_msg_cb (rd_kafka_t *rk,const rd_kafka_message_t *rkmessage, void *opaque)
 {
-	rd_kafka_opaque_t* op = (rd_kafka_opaque_t*)opaque;
+	rd_kafka_opaque_t* op = (rd_kafka_opaque_t*)rkmessage->_private;
 	if(op->sync){
 		op->ctx->co->sys_code = rkmessage->err;
 		notify_worker_dr_finished(op->ctx);


### PR DESCRIPTION
dr_msg_cb回调函数的第三个参数opaque，是指rd_kafka_conf_set_opaque设置的指针，也就是dummy_work。强转成rd_kafka_opaque_t类型，再free, 会导致crash。

获取rd_kafka_produce传递的msg_opaque参数，应该使用rkmessage->_private字段。